### PR TITLE
Update Error.hs to include an `extensions` entry

### DIFF
--- a/graphql-client/src/Data/GraphQL/Error.hs
+++ b/graphql-client/src/Data/GraphQL/Error.hs
@@ -26,6 +26,7 @@ data GraphQLError = GraphQLError
   { message :: Text
   , locations :: Maybe [GraphQLErrorLoc]
   , path :: Maybe [Value]
+  , extensions :: Maybe Value
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 

--- a/graphql-client/test/Data/GraphQL/Test/Monad/Class.hs
+++ b/graphql-client/test/Data/GraphQL/Test/Monad/Class.hs
@@ -38,7 +38,7 @@ testRunQuery =
   testGroup
     "runQuery <-> runQuerySafe"
     [ testCase "runQuery throws if runQuerySafe returns an error" $ do
-        let err = GraphQLError "Something went wrong" Nothing Nothing
+        let err = GraphQLError "Something went wrong" Nothing Nothing Nothing
         result <- try $ runMockQueryM (Left err) (runQuery TestQuery)
         show <$> result @?= Left (GraphQLException [err])
     , testCase "runQuery returns the result of runQuerySafe" $ do


### PR DESCRIPTION
The GraphQL [spec](https://spec.graphql.org/October2021/#sec-Errors.Error-result-format) allows for an `extensions` entry to exist within `errors` entries:

> GraphQL services may provide an additional entry to errors with key extensions. This entry, if set, must have a map as its value. This entry is reserved for implementors to add additional information to errors however they see fit, and there are no additional restrictions on its contents.

This commit adds the `extensions` key as a flexible `Value`.