### PR TITLE
Derive JSON object via template haskell

### DIFF
--- a/graphql-client/src/Data/GraphQL/Error.hs
+++ b/graphql-client/src/Data/GraphQL/Error.hs
@@ -26,6 +26,7 @@ data GraphQLError = GraphQLError
   { message :: Text
   , locations :: Maybe [GraphQLErrorLoc]
   , path :: Maybe [Value]
+  , extensions :: Maybe Value
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 

--- a/graphql-client/test/Data/GraphQL/Test/Monad/Class.hs
+++ b/graphql-client/test/Data/GraphQL/Test/Monad/Class.hs
@@ -38,7 +38,7 @@ testRunQuery =
   testGroup
     "runQuery <-> runQuerySafe"
     [ testCase "runQuery throws if runQuerySafe returns an error" $ do
-        let err = GraphQLError "Something went wrong" Nothing Nothing
+        let err = GraphQLError "Something went wrong" Nothing Nothing Nothing
         result <- try $ runMockQueryM (Left err) (runQuery TestQuery)
         show <$> result @?= Left (GraphQLException [err])
     , testCase "runQuery returns the result of runQuerySafe" $ do

--- a/graphql-codegen-haskell/src/index.test.ts
+++ b/graphql-codegen-haskell/src/index.test.ts
@@ -19,11 +19,14 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
     {-# LANGUAGE OverloadedStrings #-}
     {-# LANGUAGE QuasiQuotes #-}
     {-# LANGUAGE RecordWildCards #-}
+    {-# LANGUAGE TemplateHaskell #-}
     {-# LANGUAGE TypeFamilies #-}
     {-# OPTIONS_GHC -w #-}
 
     module Example.GraphQL.API where
 
+    import Data.Aeson
+    import Data.Aeson.TH
     import Data.GraphQL
     import Data.GraphQL.Bootstrap
 
@@ -50,6 +53,8 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
       }
       deriving (Show)
 
+    $(deriveJSON defaultOptions {fieldLabelModifier = drop 1} ''GetEnumsQuery)
+
     type GetEnumsSchema = [schema|
       {
         enumFoo: Maybe EnumFoo,
@@ -69,9 +74,7 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
         }
       |]
 
-      getArgs GetEnumsQuery{} = object
-        [
-        ]
+      getArgs GetEnumsQuery{} = toJSON GetEnumsQuery{}
 
     {-----------------------------------------------------------------------------
     -- getMoreEnums
@@ -92,6 +95,8 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
       }
       deriving (Show)
 
+    $(deriveJSON defaultOptions {fieldLabelModifier = drop 1} ''GetMoreEnumsQuery)
+
     type GetMoreEnumsSchema = [schema|
       {
         enumFoo: Maybe EnumFoo,
@@ -109,9 +114,7 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
         }
       |]
 
-      getArgs GetMoreEnumsQuery{} = object
-        [
-        ]
+      getArgs GetMoreEnumsQuery{} = toJSON GetMoreEnumsQuery{}
 
     {-----------------------------------------------------------------------------
     -- getBar
@@ -131,6 +134,8 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
       { _x :: Int
       }
       deriving (Show)
+
+    $(deriveJSON defaultOptions {fieldLabelModifier = drop 1} ''GetBarQuery)
 
     type GetBarSchema = [schema|
       {
@@ -155,9 +160,7 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
         }
       |]
 
-      getArgs GetBarQuery{..} = object
-        [ \\"x\\" .= _x
-        ]
+      getArgs GetBarQuery{..} = toJSON GetBarQuery{..}
 
     {-----------------------------------------------------------------------------
     -- getNamed
@@ -177,6 +180,8 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
       { _s :: Text
       }
       deriving (Show)
+
+    $(deriveJSON defaultOptions {fieldLabelModifier = drop 1} ''GetNamedQuery)
 
     type GetNamedSchema = [schema|
       {
@@ -217,9 +222,7 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
         }
       |]
 
-      getArgs GetNamedQuery{..} = object
-        [ \\"s\\" .= _s
-        ]
+      getArgs GetNamedQuery{..} = toJSON GetNamedQuery{..}
 
     {-----------------------------------------------------------------------------
     -- getNamed2
@@ -239,6 +242,8 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
       { _s :: Text
       }
       deriving (Show)
+
+    $(deriveJSON defaultOptions {fieldLabelModifier = drop 1} ''GetNamed2Query)
 
     type GetNamed2Schema = [schema|
       {
@@ -268,9 +273,7 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
         }
       |]
 
-      getArgs GetNamed2Query{..} = object
-        [ \\"s\\" .= _s
-        ]
+      getArgs GetNamed2Query{..} = toJSON GetNamed2Query{..}
 
     {-----------------------------------------------------------------------------
     -- getNamedWithLiteralParam
@@ -290,6 +293,8 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
       {
       }
       deriving (Show)
+
+    $(deriveJSON defaultOptions {fieldLabelModifier = drop 1} ''GetNamedWithLiteralParamQuery)
 
     type GetNamedWithLiteralParamSchema = [schema|
       {
@@ -312,9 +317,7 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
         }
       |]
 
-      getArgs GetNamedWithLiteralParamQuery{} = object
-        [
-        ]
+      getArgs GetNamedWithLiteralParamQuery{} = toJSON GetNamedWithLiteralParamQuery{}
 
     "
   `)
@@ -322,6 +325,7 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
   expect(outputFile('src/Example/GraphQL/Enums/EnumBar.hs'))
     .toMatchInlineSnapshot(`
     "{-# LANGUAGE TemplateHaskell #-}
+    {-# OPTIONS_GHC -w #-}
 
     module Example.GraphQL.Enums.EnumBar where
 
@@ -337,6 +341,7 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
   expect(outputFile('src/Example/GraphQL/Enums/EnumFoo.hs'))
     .toMatchInlineSnapshot(`
     "{-# LANGUAGE TemplateHaskell #-}
+    {-# OPTIONS_GHC -w #-}
 
     module Example.GraphQL.Enums.EnumFoo where
 

--- a/graphql-codegen-haskell/src/render/templates/api.mustache
+++ b/graphql-codegen-haskell/src/render/templates/api.mustache
@@ -5,11 +5,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -w #-}
 
 module {{apiModule}} where
 
+import Data.Aeson
+import Data.Aeson.TH
 import Data.GraphQL
 import Data.GraphQL.Bootstrap
 
@@ -44,6 +47,8 @@ data {{queryName}} = {{queryName}}
   }
   deriving (Show)
 
+$(deriveJSON defaultOptions {fieldLabelModifier = drop 1} ''{{queryName}})
+
 type {{schemaType}} = [schema|
   {{schema}}
 |]
@@ -57,10 +62,6 @@ instance GraphQLQuery {{queryName}} where
     {{queryText}}
   |]
 
-  getArgs {{queryName}}{{argsRecordSyntax}} = object
-    {{#overArgs}}
-    [ "{{arg}}" .= _{{arg}}
-    {{/overArgs}}
-    ]
+  getArgs {{queryName}}{{argsRecordSyntax}} = toJSON {{queryName}}{{argsRecordSyntax}}
 
 {{/operations}}

--- a/graphql-codegen-haskell/src/render/templates/enum.mustache
+++ b/graphql-codegen-haskell/src/render/templates/enum.mustache
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -w #-}
 
 module {{enumModuleName}} where
 


### PR DESCRIPTION
This PR switches JSON object derivation from manually creating the required JSON object to using Aeson's template haskell facilities.

This opens up the door for user-defined derivation strategies via [Aeson's `Options`](https://hackage.haskell.org/package/aeson-2.2.1.0/docs/Data-Aeson-TH.html#t:Options). This will allow users to customize the JSON payload based on the requirements of the GraphQL API they are working with. For example, enabling the [`omitNothingFields`](https://hackage.haskell.org/package/aeson-2.2.1.0/docs/Data-Aeson-TH.html#v:omitNothingFields) option in order to generate a JSON payload without `null` values.

Tested locally.